### PR TITLE
Add: activities-set-frame-name - make setting frame name optional

### DIFF
--- a/README.org
+++ b/README.org
@@ -146,6 +146,7 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 *Additions*
 + Command ~activities-rename~ renames an activity.
 + Option ~activities-after-switch-functions~, a hook called after switching to an activity.
++ Option ~activities-inhibit-frame-name~, to inhibit setting the frame name of an activity.
 
 *Changes*
 + Default time format in activities list.

--- a/README.org
+++ b/README.org
@@ -146,7 +146,7 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 *Additions*
 + Command ~activities-rename~ renames an activity.
 + Option ~activities-after-switch-functions~, a hook called after switching to an activity.
-+ Option ~activities-inhibit-frame-name~, to inhibit setting the frame name of an activity.
++ Option ~activities-set-frame-name~ sets the frame name after switching to an activity.  ([[https://github.com/alphapapa/activities.el/issues/33][#33]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 
 *Changes*
 + Default time format in activities list.

--- a/activities.el
+++ b/activities.el
@@ -279,8 +279,8 @@ prefixes will be added automatically."
                  (const :tag "Current project's name" activities--project-name)
                  (function-item :tag "Other function")))
 
-(defcustom activities-inhibit-frame-name nil
-  "Whether to inibit setting the frame name to the current activity name.
+(defcustom activities-set-frame-name t
+  "Set frame name after switching activity.
 Only applies when `activities-tabs-mode' is disabled."
   :type 'boolean)
 
@@ -539,7 +539,7 @@ is not changed."
     ;; (I don't love this solution, largely because it only applies
     ;; when not using `activities-tabs-mode', but it will do for now.)
     (raise-frame))
-  (unless activities-inhibit-frame-name
+  (when activities-set-frame-name
     (set-frame-name (activities-name-for activity))))
 
 (defun activities--frame (activity)

--- a/activities.el
+++ b/activities.el
@@ -279,6 +279,11 @@ prefixes will be added automatically."
                  (const :tag "Current project's name" activities--project-name)
                  (function-item :tag "Other function")))
 
+(defcustom activities-inhibit-frame-name nil
+  "Whether to inibit setting the frame name to the current activity name.
+Only applies when `activities-tabs-mode' is disabled."
+  :type 'boolean)
+
 (defcustom activities-anti-save-predicates
   '(active-minibuffer-window activities--backtrace-visible-p)
   "Predicates which prevent an activity's state from being saved.
@@ -534,7 +539,8 @@ is not changed."
     ;; (I don't love this solution, largely because it only applies
     ;; when not using `activities-tabs-mode', but it will do for now.)
     (raise-frame))
-  (set-frame-name (activities-name-for activity)))
+  (unless activities-inhibit-frame-name
+    (set-frame-name (activities-name-for activity))))
 
 (defun activities--frame (activity)
   "Return ACTIVITY's frame."

--- a/activities.info
+++ b/activities.info
@@ -414,6 +414,10 @@ File: README.info,  Node: v06-pre,  Next: v051,  Up: Changelog
    • Command ‘activities-rename’ renames an activity.
    • Option ‘activities-after-switch-functions’, a hook called after
      switching to an activity.
+   • Option ‘activities-set-frame-name’ sets the frame name after
+     switching to an activity.  (#33
+     (https://github.com/alphapapa/activities.el/issues/33).  Thanks to
+     JD Smith (https://github.com/jdtsmith).)
 
    *Changes*
    • Default time format in activities list.
@@ -635,20 +639,20 @@ Node: Bookmarks10725
 Node: FAQ11077
 Node: Changelog14153
 Node: v06-pre14467
-Node: v05115015
-Node: v0515178
-Node: v0417155
-Node: v03317696
-Node: v03218126
-Node: v03118254
-Node: v0318584
-Node: v0218974
-Node: v01319466
-Node: v01219617
-Node: v01119796
-Node: v0119961
-Node: Development20062
-Node: Copyright assignment20334
+Node: v05115242
+Node: v0515405
+Node: v0417382
+Node: v03317923
+Node: v03218353
+Node: v03118481
+Node: v0318811
+Node: v0219201
+Node: v01319693
+Node: v01219844
+Node: v01120023
+Node: v0120188
+Node: Development20289
+Node: Copyright assignment20561
 
 End Tag Table
 


### PR DESCRIPTION
Fixes #33.  This can be used with a custom `frame-title-format`, e.g.:

```elisp
(setq frame-title-format
	`((:eval (when-let ((activities-mode)
			    (cur (activities-current)))
		   (concat (activities-name-for cur) " • ")))
	  ,@frame-title-format))
```