### PR TITLE
Fix: (activities-list-command) Use vtable-revert-command

### DIFF
--- a/README.org
+++ b/README.org
@@ -156,6 +156,7 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 *Fixes*
 + Race condition when restoring multiple activities in rapid succession from user code.  ([[https://github.com/alphapapa/activity.el/pull/98][#98]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 + Command ~activities-resume~ resets when called with a universal prefix argument.  ([[https://github.com/alphapapa/activities.el/pull/75][#75]].  Thanks to [[https://breatheoutbreathe.in][Joseph Turner]].)
++ Refreshing activities list.  ([[https://github.com/alphapapa/activities.el/pull/77][#77]].  Thanks to [[https://breatheoutbreathe.in][Joseph Turner]].)
 
 ** v0.7
 

--- a/activities-list.el
+++ b/activities-list.el
@@ -42,7 +42,7 @@
      (let ((list-buffer (current-buffer)))
        (apply #',command args)
        (with-current-buffer list-buffer
-         (vtable-revert)))))
+         (vtable-revert-command)))))
 
 ;;;###autoload
 (defun activities-list ()


### PR DESCRIPTION
It seems to be necessary to clear the vtable cache in order for the listings to properly refresh.