### PR TITLE
Fix: Use default tab-bar-tab-face-function

### DIFF
--- a/activities-tabs.el
+++ b/activities-tabs.el
@@ -202,10 +202,11 @@ Selects its tab, making one if needed.  Its state is not changed."
 If TAB represents an activity, face `activities-tabs' is added as
 inherited."
   ;; TODO: Propose a tab-bar equivalent of `tab-line-tab-face-functions'.
-  (let ((face (funcall activities-tabs-tab-bar-tab-face-function-original tab)))
-    (if (activities-tabs--tab-parameter 'activity tab)
-        `(:inherit (activities-tabs ,face))
-      face)))
+  ;; (let ((face (funcall activities-tabs-tab-bar-tab-face-function-original tab)))
+  ;;   (if (activities-tabs--tab-parameter 'activity tab)
+  ;;       `(:inherit (activities-tabs ,face))
+  ;;     face))
+  (funcall activities-tabs-tab-bar-tab-face-function-original tab))
 
 (defun activities-tabs-activity--set (activity)
   "Set the current activity.


### PR DESCRIPTION
This resolves a problem where activities tabs were not resized when the tab-bar-auto-width option is non-nil.

Internally, the tab-bar-auto-width function determines that a tab should be resized if its face is one of tab-bar-auto-width-faces. However, activities-tabs--tab-bar-tab-face-function sets the activities tab face to (:inherit (activities-tabs ,face)), so the activities tabs were never resized.

By using the default face, the memq check works as intended.

Resolves #76.