### PR TITLE
annotations and sorting for activities-completing-read

### DIFF
--- a/README.org
+++ b/README.org
@@ -164,7 +164,11 @@ The sort order when completing activities can be configured using ~activities-so
 
 ** v0.8-pre
 
-Nothing new yet.
+*Additions*
++ New completion interface with rich annotations. (See #83.)
+
+*Changes*
++ During save, the ~time~ slot for an activity remains unchanged unless its buffers or files differ from their last saved state. (See #83.)
 
 ** v0.7.2
 

--- a/README.org
+++ b/README.org
@@ -135,6 +135,10 @@ Key bindings are, as always, ultimately up to the user.  However, in [[Configura
 
 When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored when a new activity is made.  This allows the command ~bookmark-jump~ (~C-x r b~) to be used to resume an activity (helping to universalize the bookmark system).
 
+** Annotation Info
+
+When selecting an activity in the minibuffer using an interface that supports /annotations/, additional information is shown: the number of buffers and files the activity contains, a color-coded age since the activity was last updated, and a final ~*~ if the activity's list of buffers has been modified from its default state.
+
 * FAQ
 
 + How is this different from [[https://github.com/alphapapa/burly.el][Burly.el]] or [[https://github.com/alphapapa/bufler.el/][Bufler.el]]? :: Burly is a well-polished tool for restoring window and frame configurations, which could be considered an incubator for some of the ideas furthered here.  Bufler's ~bufler-workspace~ library uses Burly to provide some similar functionality, which is at an exploratory stage.  ~activities~ hopes to provide a longer-term solution more suitable for integration into Emacs.

--- a/README.org
+++ b/README.org
@@ -137,12 +137,14 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 
 ** Completion
 
-When selecting an activity in the mini-buffer, annotations are sorted active first, then by most recent modification age.  If you are using an interface that supports /annotations/, additional information is shown alongside the activity name:
+When selecting an activity in the mini-buffer, if you are using an interface that supports /annotations/, additional information is shown alongside the activity name:
 
 - an `@` symbol, for active activities,
 - the number of buffers and files the activity contains,
 - a color-coded age since the activity was last updated, and
 - a final ~*~ if the activity's list of buffers and files has been modified from its default state.
+
+The sort order when completing activities can be configured using ~activities-sort-by~.
 
 * FAQ
 

--- a/README.org
+++ b/README.org
@@ -137,12 +137,12 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 
 ** Completion
 
-When selecting an activity in the mini-buffer, if you are using an interface that supports /annotations/, additional information is shown alongside the activity name:
+When selecting an activity in the minibuffer, if you are using an interface that supports /annotations/, additional information is shown alongside the activity name:
 
-- an `@` symbol, for active activities,
-- the number of buffers and files the activity contains,
-- a color-coded age since the activity was last updated, and
-- a final ~*~ if the activity's list of buffers and files has been modified from its default state.
+- An ~@~ symbol for active activities,
+- The number of buffers and files the activity contains,
+- A color-coded age (elapsed time since the activity was last updated), and
+- A final ~*~ if the activity's list of buffers and files has been modified from its default state.
 
 The sort order when completing activities can be configured using ~activities-sort-by~.
 
@@ -165,10 +165,10 @@ The sort order when completing activities can be configured using ~activities-so
 ** v0.8-pre
 
 *Additions*
-+ New completion interface with rich annotations. (See #83.)
++ New completion interface with rich annotations.  ([[https://github.com/alphapapa/activity.el/pull/83][#83]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 
 *Changes*
-+ During save, the ~time~ slot for an activity remains unchanged unless its buffers or files differ from their last saved state. (See #83.)
++ During save, the ~time~ slot for an activity remains unchanged unless its buffers or files differ from their last saved state.  ([[https://github.com/alphapapa/activity.el/pull/83][#83]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 
 ** v0.7.2
 

--- a/README.org
+++ b/README.org
@@ -135,9 +135,14 @@ Key bindings are, as always, ultimately up to the user.  However, in [[Configura
 
 When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored when a new activity is made.  This allows the command ~bookmark-jump~ (~C-x r b~) to be used to resume an activity (helping to universalize the bookmark system).
 
-** Annotation Info
+** Annotation and Sort
 
-When selecting an activity in the minibuffer using an interface that supports /annotations/, additional information is shown: the number of buffers and files the activity contains, a color-coded age since the activity was last updated, and a final ~*~ if the activity's list of buffers has been modified from its default state.
+When selecting an activity in the mini-buffer, annotations are sorted active first, then by most recent modification age.  If you are using an interface that supports /annotations/, additional information is shown alongside the activity name:
+
+- an `@` symbol, for active activities,
+- the number of buffers and files the activity contains,
+- a color-coded age since the activity was last updated, and
+- a final ~*~ if the activity's list of buffers and files has been modified from its default state.
 
 * FAQ
 

--- a/README.org
+++ b/README.org
@@ -135,7 +135,7 @@ Key bindings are, as always, ultimately up to the user.  However, in [[Configura
 
 When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored when a new activity is made.  This allows the command ~bookmark-jump~ (~C-x r b~) to be used to resume an activity (helping to universalize the bookmark system).
 
-** Annotation and Sort
+** Completion
 
 When selecting an activity in the mini-buffer, annotations are sorted active first, then by most recent modification age.  If you are using an interface that supports /annotations/, additional information is shown alongside the activity name:
 

--- a/activities.el
+++ b/activities.el
@@ -341,7 +341,9 @@ applied.  A custom predicate function may also be set.  It should
 take two arguments, both activity names (strings), and return
 non-nil if the first activity should sort before the second."
   :type `(choice (const :tag "No sorting" nil)
-		 (const :tag "Active state and age" ,#'activities-sort-by-active-age)
+		 (function-item :tag "Active state and age"
+				:doc "Sort by active state and age."
+				,#'activities-sort-by-active-age)
 		 (function :tag "Custom predicate")))
 
 (defcustom activities-annotation-colors '("blue" "red" 0.65)

--- a/activities.el
+++ b/activities.el
@@ -850,11 +850,9 @@ Adapted from `magit--age'."
   (cl-loop for (_name . act) in activities maximize
 	   (cl-loop
 	    for type in '(default last)
-	    for func = (intern (format "activities-activity-%s" type))
-	    maximize
-	    (float-time
-	     (time-since
-	      (map-elt (activities-activity-state-etc (funcall func act)) 'time))))))
+ 	    for state = (cl-struct-slot-value 'activities-activity type act)
+	    for etc = (activities-activity-state-etc state)
+	    maximize (float-time (time-since (map-elt etc 'time))))))
 
 (defun activities-annotate (max-age oldest-possible)
   "Return an activity annotation function.
@@ -864,8 +862,7 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
     (when-let ((activity (map-elt activities-activities name)))
       (let (data (age-len 14))
 	(dolist (type '(last default))
-	  (let* ((func (intern (format "activities-activity-%s" type)))
-		 (state (funcall func activity))
+	  (let* ((state (cl-struct-slot-value 'activities-activity type activity))
 		 (time (map-elt (activities-activity-state-etc state) 'time))
 		 (window-state (activities-activity-state-window-state state))
 		 (buffers (window-state-buffers window-state))

--- a/activities.el
+++ b/activities.el
@@ -535,8 +535,10 @@ form (BUFFER . FILE) assocaited with the activity."
   (activities--map-window-state-leafs
    (activities-activity-state-window-state state)
    (lambda (leaf)
-     (let ((rec (map-nested-elt (cdr leaf) '(parameters activities-buffer))))
-       (cons (activities-buffer-name rec) (activities-buffer-filename rec))))))
+     (let ((buffer-rec (map-nested-elt (cdr leaf)
+				       '(parameters activities-buffer))))
+       (cons (activities-buffer-name buffer-rec)
+	     (activities-buffer-filename buffer-rec))))))
 
 (defun activities--buffers-and-files-differ-p (bf1 bf2)
   "Return non-nil if BF1 and BF2 are not the same set of files or buffers.

--- a/activities.el
+++ b/activities.el
@@ -846,7 +846,7 @@ Adapted from `magit--age'."
     (fn age activities--age-spec)))
 
 (defun activities--oldest-age (activities)
-  "Return the age in seconds of the olds of ACTIVITIES."
+  "Return the age in seconds of the oldest activity in ACTIVITIES."
   (cl-loop for (_name . act) in activities maximize
 	   (cl-loop
 	    for type in '(default last)

--- a/activities.el
+++ b/activities.el
@@ -864,7 +864,8 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 		 (time (map-elt (activities-activity-state-etc state) 'time))
 		 (window-state (activities-activity-state-window-state state))
 		 (buffers (window-state-buffers window-state))
-		 (files (activities--map-window-state-leafs window-state
+		 (files (activities--map-window-state-leafs
+			 window-state
 			 (lambda (leaf)
 			   (bookmark-get-filename
 			    (activities-buffer-bookmark

--- a/activities.el
+++ b/activities.el
@@ -863,7 +863,7 @@ Adapted from `magit--age'."
 	    for etc = (activities-activity-state-etc state)
 	    maximize (float-time (time-since (map-elt etc 'time))))))
 
-(defun activities-annotate (max-age oldest-possible)
+(defun activities--annotate (max-age oldest-possible)
   "Return an activity annotation function.
 MAX-AGE is the maximum age of any activity in seconds.
 OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
@@ -899,7 +899,6 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 		       (dirtyp (when last-buffers-and-files
 				 (buffers-and-files-differ-p last-buffers-and-files
 							     default-buffers-and-files)))
-		       (dirty-annotation (if dirtyp (propertize "*" 'face 'bold) " "))
 		       (annotation (format "%s%s buf%s %s file%s "
 					   (if (activities-activity-active-p activity)
 					       (propertize "@" 'face 'bold) " ")
@@ -915,7 +914,8 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 					(format "%15s" (apply #'format "[%d %s]"
 							      (activities--age age)))
 					'face `(:foreground ,age-color
-							    :background ,vc-annotate-background))))
+							    :background ,vc-annotate-background)))
+		       (dirty-annotation (if dirtyp (propertize "*" 'face 'bold) " ")))
 	    (concat (propertize " " 'display
 				`(space :align-to (- right ,(+ 1 (length annotation)
 							       (length age-annotation)))))
@@ -945,7 +945,7 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
     (lambda (str pred action)
       (if (eq action 'metadata)
 	  `(metadata
-	    (annotation-function . ,(activities-annotate (activities--oldest-age activities)
+	    (annotation-function . ,(activities--annotate (activities--oldest-age activities)
 							 (vc-annotate-oldest-in-map
 							  vc-annotate-color-map)))
 	    ,@(when activities-sort-function

--- a/activities.el
+++ b/activities.el
@@ -902,13 +902,12 @@ Abbreviate the units if ABBREV is non-nil."
 
 (defun activities--oldest-age (activities)
   "Return the age in seconds of the oldest activity in ACTIVITIES."
-  (cl-loop for (_name . act) in activities maximize
-	   (cl-loop
-	    for type in '(default last)
- 	    for state = (cl-struct-slot-value 'activities-activity type act)
-	    if state
-	    for etc = (activities-activity-state-etc state)
-	    maximize (float-time (time-since (map-elt etc 'time))))))
+  (cl-loop for (_name . activity) in activities
+	   for state = (pcase-let (((cl-struct activities-activity default last) activity))
+			 (or last default))
+	   if state
+	   for etc = (activities-activity-state-etc state)
+	   maximize (float-time (time-since (map-elt etc 'time)))))
 
 (defun activities-sort-by-active-age (names)
   "Return the list of activity NAMES sorted active first, then by age."

--- a/activities.el
+++ b/activities.el
@@ -935,8 +935,6 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 			      (activities-activity-default activity-b)))
 		 (time-b (map-elt (activities-activity-state-etc state-b) 'time))
 		 (activep-b (activities-activity-active-p activity-b)))
-	    (message "Comparing %s %s timeA: %S timeB: %S activeA: %S activeB: %S" a b
-		     (format-time-string "%F %r" time-a) (format-time-string "%F %r" time-b) activep-a activep-b)
 	    (or (and activep-a (not activep-b)) (time-less-p time-b time-a))))))
 
 (defun activities--completion-table (activities)

--- a/activities.el
+++ b/activities.el
@@ -904,9 +904,9 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 					   (if (activities-activity-active-p activity)
 					       (propertize "@" 'face 'bold) " ")
 					   (propertize (format "%2d" num-buffers) 'face 'success)
-					   (if (> num-buffers 1) "s" " ")
+					   (if (= num-buffers 1) " " "s")
 					   (propertize (format "%2d" num-files) 'face 'warning)
-					   (if (> num-files 1) "s" " ")))
+					   (if (= num-files 1) " " "s")))
 		       (age-color (or (cdr (vc-annotate-compcar
 					    (* (/ age max-age) oldest-possible)
 					    vc-annotate-color-map))

--- a/activities.el
+++ b/activities.el
@@ -921,8 +921,8 @@ Abbreviate the units if ABBREV is non-nil."
 		  (cons time active-p))))
     (sort names (pcase-lambda ((app time-active-p `(,time-a . ,activep-a))
 			       (app time-active-p `(,time-b . ,activep-b)))
-		  (or (and activep-a (not activep-b))
-		      (time-less-p time-b time-a))))))
+		  (if (xor activep-a activep-b) activep-a
+		    (time-less-p time-b time-a))))))
 
 (cl-defun activities-completing-read
     (&key (activities activities-activities)

--- a/activities.el
+++ b/activities.el
@@ -864,12 +864,12 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 		 (time (map-elt (activities-activity-state-etc state) 'time))
 		 (window-state (activities-activity-state-window-state state))
 		 (buffers (window-state-buffers window-state))
-		 (files ( activities--map-window-state-leafs window-state
-			  (lambda (l)
-			    (bookmark-get-filename
-			     (activities-buffer-bookmark
-			      (map-nested-elt (cdr l)
-					      '(parameters activities-buffer))))))))
+		 (files (activities--map-window-state-leafs window-state
+			 (lambda (l)
+			   (bookmark-get-filename
+			    (activities-buffer-bookmark
+			     (map-nested-elt (cdr l)
+			 		     '(parameters activities-buffer))))))))
 	    (setf (alist-get type data)
 		  (list (length buffers)
 			(length (delq nil files))

--- a/activities.el
+++ b/activities.el
@@ -875,30 +875,30 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 	      (setf (alist-get type data)
 		    (list (length (delq nil files))
 			  (and time (float-time (time-since time))) buffers)))))
-	(pcase-let* ((`(,last-file-cnt ,last-age ,last-bufs) (map-elt data 'last))
-		     (`(,default-file-cnt ,default-age ,default-bufs) (map-elt data 'default))
+	(pcase-let* ((`(,num-last-files ,last-age ,last-buffers) (map-elt data 'last))
+		     (`(,num-default-files ,default-age ,default-buffers) (map-elt data 'default))
 		     (age (if last-age (min last-age default-age) default-age))
-		     (buf-cnt (length (or last-bufs default-bufs)))
-		     (file-cnt (or last-file-cnt default-file-cnt))
-		     (dirty (and last-bufs
-				 (or (/= (length last-bufs) (length default-bufs))
-				     (not (seq-set-equal-p last-bufs default-bufs)))))
-		     (ann (format "%s bufs %s files "
-				  (propertize (format "%2d" buf-cnt) 'face 'success)
-				  (propertize (format "%2d" file-cnt) 'face 'warning)))
+		     (num-buffers (length (or last-buffers default-buffers)))
+		     (num-files (or num-last-files num-default-files))
+		     (dirtyp (when last-buffers
+			       (or (/= (length last-buffers) (length default-buffers))
+				   (not (seq-set-equal-p last-buffers default-buffers)))))
+		     (annotation (format "%s bufs %s files "
+					 (propertize (format "%2d" num-buffers) 'face 'success)
+					 (propertize (format "%2d" num-files) 'face 'warning)))
 		     (age-color (or (cdr (vc-annotate-compcar
 					  (* (/ age max-age) oldest-possible)
 					  vc-annotate-color-map))
 				    vc-annotate-very-old-color))
-		     (age-ann (propertize
-			       (format "%15s" (apply #'format "[%d %s]" (activities--age age)))
-			       'face `( :foreground ,age-color
-					:background ,vc-annotate-background)))
-		     (dirty-ann (propertize (if dirty "*" " ") 'face 'bold)))
+		     (age-annotation (propertize
+				      (format "%15s" (apply #'format "[%d %s]" (activities--age age)))
+				      'face `(:foreground ,age-color
+							  :background ,vc-annotate-background)))
+		     (dirty-annotation (propertize (if dirtyp "*" " ") 'face 'bold)))
 	  (concat (propertize " " 'display
-			      `( space :align-to
-				 (- right ,(+ (length ann) (length age-ann) 1))))
-		  ann age-ann dirty-ann))))))
+			      `(space :align-to
+				      (- right ,(+ (length annotation) (length age-annotation) 1))))
+		  annotation age-annotation dirty-annotation))))))
 
 (cl-defun activities-completing-read
     (&key (activities activities-activities)

--- a/activities.el
+++ b/activities.el
@@ -901,6 +901,11 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 					(format "%15s" (apply #'format "[%d %s]"
 							      (activities--age age)))
 					'face `(:foreground ,age-color
+							    :background ,vc-annotate-background)))
+		       (dirty-char (cond ((and activep dirtyp) "*")
+					 (activep "+") (dirtyp "-") (t " ")))
+		       (dirty-annotation (propertize dirty-char 'face 'bold)))
+	    (concat (propertize " " 'display
 				`(space :align-to (- right ,(+ 1 (length annotation)
 							       (length age-annotation)))))
 		    annotation age-annotation dirty-annotation)))))))

--- a/activities.el
+++ b/activities.el
@@ -546,7 +546,8 @@ form (BUFFER . FILE) assocaited with the activity."
 Each of BF1 and BF2 is a list of buffer and files, as returned
 from `activities--buffers-and-files'."
   (cl-labels ((file-or-buffer (cell)
-		"Given (buffer . file), return the true filename or (if none) buffer."
+		"Given a CELL, return the true filename or buffer.
+The CELL is a (BUFFER . FILE) cons.  If the file is nil, BUFFER is returned."
 		(if (cdr cell) (file-truename (cdr cell)) (car cell))))
     (not (seq-set-equal-p (mapcar #'file-or-buffer bf1)
 			  (mapcar #'file-or-buffer bf2)))))

--- a/activities.el
+++ b/activities.el
@@ -881,9 +881,9 @@ activity's name is NAME."
 
 (defun activities--age (age &optional abbrev)
   "Summarize AGE.
-Abbreviate the units if ABBREV is non-nil.  Based on
-`magit--age'."
-  ;; TODO: replace this if seconds-to-string adds READABLE support
+Abbreviate the units if ABBREV is non-nil."
+  ;; Based orginally on `magit--age'."
+  ;; TODO: replace this if seconds-to-string adds READABLE support; see bug#71572
   (let ((half t)
 	(age-spec activities--age-spec)
 	age-unit cnt)

--- a/activities.el
+++ b/activities.el
@@ -889,8 +889,10 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 		       (dirtyp (when last-buffers-and-files
 				 (buffers-and-files-differ-p last-buffers-and-files
 							     default-buffers-and-files)))
-		       (activep (activities-activity-active-p activity))
-		       (annotation (format "%s bufs %s files "
+		       (dirty-annotation (if dirtyp (propertize "*" 'face 'bold) " "))
+		       (annotation (format "%s%s bufs %s files "
+					   (if (activities-activity-active-p activity)
+					       (propertize "@" 'face 'bold) " ")
 					   (propertize (format "%2d" num-buffers) 'face 'success)
 					   (propertize (format "%2d" num-files) 'face 'warning)))
 		       (age-color (or (cdr (vc-annotate-compcar
@@ -901,10 +903,7 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 					(format "%15s" (apply #'format "[%d %s]"
 							      (activities--age age)))
 					'face `(:foreground ,age-color
-							    :background ,vc-annotate-background)))
-		       (dirty-char (cond ((and activep dirtyp) "*")
-					 (activep "+") (dirtyp "-") (t " ")))
-		       (dirty-annotation (propertize dirty-char 'face 'bold)))
+							    :background ,vc-annotate-background))))
 	    (concat (propertize " " 'display
 				`(space :align-to (- right ,(+ 1 (length annotation)
 							       (length age-annotation)))))

--- a/activities.el
+++ b/activities.el
@@ -551,16 +551,16 @@ form (BUFFER . FILE) associated with the activity."
        (cons (activities-buffer-name buffer-rec)
 	     (activities-buffer-filename buffer-rec))))))
 
-(defun activities--buffers-and-files-differ-p (bf1 bf2)
-  "Return non-nil if BF1 and BF2 are not the same set of files or buffers.
-Each of BF1 and BF2 is a list of buffer and files, as returned
+(defun activities--buffers-and-files-differ-p (bfa bfb)
+  "Return non-nil if BFA and BFB are not the same set of files or buffers.
+Each of BFA and BFB is a list of buffer and files, as returned
 from `activities--buffers-and-files'."
   (cl-labels ((file-or-buffer (cell)
 		"Given a CELL, return the true filename or buffer.
 The CELL is a (BUFFER . FILE) cons.  If the file is nil, BUFFER is returned."
 		(if (cdr cell) (file-truename (cdr cell)) (car cell))))
-    (not (seq-set-equal-p (mapcar #'file-or-buffer bf1)
-			  (mapcar #'file-or-buffer bf2)))))
+    (not (seq-set-equal-p (mapcar #'file-or-buffer bfa)
+			  (mapcar #'file-or-buffer bfb)))))
 
 (cl-defun activities-save (activity &key defaultp lastp persistp)
   "Save states of ACTIVITY.

--- a/activities.el
+++ b/activities.el
@@ -332,15 +332,17 @@ Kills buffers that have only been shown in that activity's
 frame/tab."
   :type 'boolean)
 
-(defcustom activities-sort-function #'activities-sort-by-active-age
-  "A function to use to sort by when prompting for activities.
-If nil, no sorting will be applied.  The function should take two
-arguments, both activity names (strings).  It should return
-non-nil if the first activity should sort before the second.  By
+(defcustom activities-sort-by #'activities-sort-by-active-age
+  "How to sort activities during selection.
+Function used to sort by when prompting for activities.  By
 default, a function is used which sorts active activities first,
-and then by age since modification."
-  :type '(choice (const :tag "No sorting" nil)
-		 (function :tag "A specific function")))
+and then by age since modification.  If nil, no sorting will be
+applied.  A custom predicate function may also be set.  It should
+take two arguments, both activity names (strings), and return
+non-nil if the first activity should sort before the second."
+  :type `(choice (const :tag "No sorting" nil)
+		 (const :tag "Active state and age" ,#'activities-sort-by-active-age)
+		 (function :tag "Custom predicate")))
 
 (defcustom activities-annotation-colors '("blue" "red" 0.65)
   "Colors to use for annotating activity age.
@@ -983,8 +985,8 @@ which see, with DEFAULT."
        (table (lambda (str pred action)
 		(if (eq action 'metadata)
 		    `(metadata (annotation-function . ,annotation-function)
-			       ,@(when activities-sort-function
-				   `(,(cons 'display-sort-function activities-sort-function))))
+			       ,@(when activities-sort-by
+				   `(,(cons 'display-sort-function activities-sort-by))))
 		  (complete-with-action action names str pred))))
        (prompt (format-prompt prompt default))
        (name (completing-read prompt table nil t nil 'activities-completing-read-history default)))

--- a/activities.el
+++ b/activities.el
@@ -336,12 +336,11 @@ frame/tab."
   "How to sort activities during selection.
 Function used to sort by when prompting for activities.  By
 default, a function is used which sorts active activities first,
-and then by age since modification.  If nil, no sorting will be
-applied.  A custom predicate function may also be set.  It should
-take two arguments, both activity names (strings), and return
-non-nil if the first activity should sort before the second."
-  :type `(choice (const :tag "No sorting" nil)
-		 (function-item :tag "Active state and age"
+and then by age since modification.  A custom predicate function
+may also be set.  It should take two arguments, both activity
+names (strings), and return non-nil if the first activity should
+sort before the second."
+  :type `(choice (function-item :tag "Active state and age"
 				:doc "Sort by active state and age."
 				,#'activities-sort-by-active-age)
 		 (function :tag "Custom predicate")))
@@ -985,8 +984,7 @@ which see, with DEFAULT."
 	   "Complete activities from STR, using completion PRED and ACTION."
 	   (if (eq action 'metadata)
 	       `(metadata (annotation-function . ,#'activity-annotation-function)
-			  ,@(when activities-sort-by
-			      `(,(cons 'display-sort-function activities-sort-by))))
+			  (display-sort-function . ,activities-sort-by))
 	     (complete-with-action action names str pred))))
       (let ((name (completing-read prompt #'activity-table nil t nil
 				   'activities-completing-read-history default)))

--- a/activities.el
+++ b/activities.el
@@ -556,6 +556,12 @@ according to option `activities-always-persist', which see)."
       (unless (run-hook-with-args-until-success 'activities-anti-save-predicates)
         (pcase-let* (((cl-struct activities-activity default last) activity)
                      (new-state (activities-state)))
+	  (when (and lastp last
+		     (not (activities--buffers-and-files-differ-p
+			   (activities--buffers-and-files last)
+			   (activities--buffers-and-files new-state))))
+	    (setf (map-elt (activities-activity-state-etc new-state) 'time)
+		  (map-elt (activities-activity-state-etc last) 'time)))
           (setf (activities-activity-default activity) (if (or defaultp (not default)) new-state default)
                 (activities-activity-last activity) (if (or lastp (not last)) new-state last)))))
     ;; Always set the value so, e.g. the activity can be modified

--- a/activities.el
+++ b/activities.el
@@ -542,7 +542,7 @@ each of the leaf nodes in STATE."
 (defun activities--buffers-and-files (state)
   "Return a list of buffers and files from STATE.
 STATE is a window-state.  The returned list contains elements of
-form (BUFFER . FILE) assocaited with the activity."
+form (BUFFER . FILE) associated with the activity."
   (activities--mapcar-window-state-leafs
    (activities-activity-state-window-state state)
    (lambda (leaf)

--- a/activities.el
+++ b/activities.el
@@ -845,6 +845,17 @@ Adapted from `magit--age'."
                       (fn age (cdr spec)))))))
     (fn age activities--age-spec)))
 
+(defun activities--oldest-age (activities)
+  "Return the age in seconds of the olds of ACTIVITIES."
+  (cl-loop for (_name . act) in activities maximize
+	   (cl-loop
+	    for type in '(default last)
+	    for func = (intern (format "activities-activity-%s" type))
+	    maximize
+	    (float-time
+	     (time-since
+	      (map-elt (activities-activity-state-etc (funcall func act)) 'time))))))
+
 (defun activities-annotate (max-age)
   "Return an activity annotation function.
 MAX-AGE is the maximum age of any activity in seconds."
@@ -895,17 +906,6 @@ MAX-AGE is the maximum age of any activity in seconds."
 	    (concat (propertize " " 'display
 				`(space :align-to (- right ,(+ (length ann) 13))))
 		    ann age-ann)))))))
-
-(defun activities--oldest-age (activities)
-  "Return the age in seconds of the olds of ACTIVITIES."
-  (cl-loop for (_name . act) in activities maximize
-	   (cl-loop
-	    for type in '(default last)
-	    for func = (intern (format "activities-activity-%s" type))
-	    maximize
-	    (float-time
-	     (time-since
-	      (map-elt (activities-activity-state-etc (funcall func act)) 'time))))))
 
 (cl-defun activities-completing-read
     (&key (activities activities-activities)

--- a/activities.el
+++ b/activities.el
@@ -346,11 +346,9 @@ non-nil if the first activity should sort before the second."
 
 (defcustom activities-annotation-colors '("blue" "red" 0.65)
   "Colors to use for annotating activity age.
-A list (OLD-COLOR NEW-COLOR BLEND-FRAC).  These are used during
-activity selection, with the activity color chosen between
-OLD-COLOR and NEW-COLOR, based on the activity's age.  This color
-is blended into the default foreground with a fraction
-BLEND-FRAC, and used to display the activity age."
+A list (OLD-COLOR NEW-COLOR ALPHA).  Activity color is based on
+the activity's age, varying between OLD-COLOR and NEW-COLOR, and
+blended with fraction ALPHA into the default foreground."
   :type '(list (color :tag "Old Color") (color :tag "New Color")
 	       (float :tag "Blend Fraction")))
 

--- a/activities.el
+++ b/activities.el
@@ -890,11 +890,13 @@ OLDEST-POSSIBLE is the oldest age in the `vc-annotate-color-map'."
 				 (buffers-and-files-differ-p last-buffers-and-files
 							     default-buffers-and-files)))
 		       (dirty-annotation (if dirtyp (propertize "*" 'face 'bold) " "))
-		       (annotation (format "%s%s bufs %s files "
+		       (annotation (format "%s%s buf%s %s file%s "
 					   (if (activities-activity-active-p activity)
 					       (propertize "@" 'face 'bold) " ")
 					   (propertize (format "%2d" num-buffers) 'face 'success)
-					   (propertize (format "%2d" num-files) 'face 'warning)))
+					   (if (> num-buffers 1) "s" " ")
+					   (propertize (format "%2d" num-files) 'face 'warning)
+					   (if (> num-files 1) "s" " ")))
 		       (age-color (or (cdr (vc-annotate-compcar
 					    (* (/ age max-age) oldest-possible)
 					    vc-annotate-color-map))

--- a/activities.el
+++ b/activities.el
@@ -865,7 +865,7 @@ MAX-AGE is the maximum age of any activity in seconds."
 			      '(parameters activities-buffer))))))))
 	    (setf (alist-get type data)
 		  (list :bufcnt (length buffers)
-			:filecnt (length files)
+			:filecnt (length (delq nil files))
 			:time (float-time (time-since time))))))
 	(cl-labels ((data-el (&rest keys) (map-nested-elt data keys)))
 	  (let* ((oldest (vc-annotate-oldest-in-map vc-annotate-color-map))

--- a/activities.el
+++ b/activities.el
@@ -539,7 +539,9 @@ form (BUFFER . FILE) assocaited with the activity."
        (cons (activities-buffer-name rec) (activities-buffer-filename rec))))))
 
 (defun activities--buffers-and-files-differ-p (bf1 bf2)
-  "Return t if BF1 and BF2 are not the same set of files or buffers."
+  "Return non-nil if BF1 and BF2 are not the same set of files or buffers.
+Each of BF1 and BF2 is a list of buffer and files, as returned
+from `activities--buffers-and-files'."
   (cl-labels ((file-or-buffer (cell)
 		"Given (buffer . file), return the true filename or (if none) buffer."
 		(if (cdr cell) (file-truename (cdr cell)) (car cell))))

--- a/activities.el
+++ b/activities.el
@@ -524,20 +524,20 @@ To be called from `kill-emacs-hook'."
 ;;;; Functions
 
 (defun activities--mapcar-window-state-leafs (state func)
-  "Return a list of leaf nodes value from window-state STATE.
+  "Return a list of leaf node values from window-state STATE.
 The returned list contains the values obtained by calling FUNC on
 each of the leaf nodes in STATE."
-  (let (ret)
+  (let (values)
     (cl-labels ((map-leafs (state func)
 		  (pcase state
 		    (`(leaf . ,_attrs)
-		     (push (funcall func state) ret))
+		     (push (funcall func state) values))
 		    ((pred proper-list-p)
 		     (if-let ((leaf-pos (cl-position 'leaf state)))
-			 (push (funcall func (cl-subseq state leaf-pos)) ret)
+			 (push (funcall func (cl-subseq state leaf-pos)) values)
 		       (dolist (s state) (map-leafs s func)))))))
       (map-leafs state func))
-    (nreverse ret)))
+    (nreverse values)))
 
 (defun activities--buffers-and-files (state)
   "Return a list of buffers and files from STATE.

--- a/activities.el
+++ b/activities.el
@@ -513,9 +513,10 @@ To be called from `kill-emacs-hook'."
 
 ;;;; Functions
 
-(defun activities--map-window-state-leafs (state func)
-  "Call FUNC on all the leaf nodes in window-state STATE.
-The resulting values are returned as a list."
+(defun activities--mapcar-window-state-leafs (state func)
+  "Return a list of leaf nodes value from window-state STATE.
+The returned list contains the values obtained by calling FUNC on
+each of the leaf nodes in STATE."
   (let (ret)
     (cl-labels ((map-leafs (state func)
 		  (pcase state
@@ -532,7 +533,7 @@ The resulting values are returned as a list."
   "Return a list of buffers and files from STATE.
 STATE is a window-state.  The returned list contains elements of
 form (BUFFER . FILE) assocaited with the activity."
-  (activities--map-window-state-leafs
+  (activities--mapcar-window-state-leafs
    (activities-activity-state-window-state state)
    (lambda (leaf)
      (let ((buffer-rec (map-nested-elt (cdr leaf)

--- a/activities.el
+++ b/activities.el
@@ -660,9 +660,8 @@ The resulting values are returned as a list."
 		  (pcase state
 		    (`(leaf . ,_attrs)
 		     (push (funcall func state) ret))
-		    ((pred atom) state)
-		    (`(,_key . ,(pred atom)) state)
-		    ((pred list)
+		    (`(,_key . ,(pred atom))) ; skip
+		    ((pred proper-list-p)
 		     (if-let ((leaf-pos (cl-position 'leaf state)))
 			 (push (funcall func (cl-subseq state leaf-pos)) ret)
 		       (dolist (s state) (map-leafs s func)))))))

--- a/activities.el
+++ b/activities.el
@@ -660,7 +660,6 @@ The resulting values are returned as a list."
 		  (pcase state
 		    (`(leaf . ,_attrs)
 		     (push (funcall func state) ret))
-		    (`(,_key . ,(pred atom))) ; skip
 		    ((pred proper-list-p)
 		     (if-let ((leaf-pos (cl-position 'leaf state)))
 			 (push (funcall func (cl-subseq state leaf-pos)) ret)


### PR DESCRIPTION
(updated) This provides custom annotation and sorting functions for `activities-completing-read`. It shows the number of buffers (and files), for the last or default state, a magit-style color-coded _activity age_, and flags for being active or having a modified set of buffers. 

This is shown below with `vertico` but it should support any UI which handles annotation-functions (most do).   For theme friendliness, it creates no new faces, instead ~borrowing the `vc-annotate` color palette~ building its own color palette (along with `success` and `warning` faces).  Happy to take any input/ideas.

<img width="375" alt="image" src="https://github.com/user-attachments/assets/2ef0c4d7-0113-4c79-8083-b339ee87265a">
