### PR TITLE
windows-set: avoid frame race condition

### DIFF
--- a/README.org
+++ b/README.org
@@ -153,7 +153,8 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 
 ** v0.8-pre
 
-Nothing new yet.
+*Fixes*
++ Race condition when restoring multiple activities in rapid succession from user code.  ([[https://github.com/alphapapa/activity.el/pull/98][#98]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 
 ** v0.7
 


### PR DESCRIPTION
In discussion #78 I suggested a loop over activity names, calling `activities-resume`.  This doesn't work reliably, because of the `HACK` in `activities--windows-set`, which uses an "immediate" timer.  When rapidly resuming activities in a loop, by the time the timer is called, the frame will have changed, and the activities' contents are bungled.