### PR TITLE
Change for #88 - activities-save-all adjusts height minibuffer

### DIFF
--- a/activities.el
+++ b/activities.el
@@ -434,13 +434,14 @@ With PERSISTP, persist to disk (otherwise see
 `activities-always-persist').  To be safe for `kill-emacs-hook',
 this demotes errors."
   (interactive)
-  (with-demoted-errors "activities-save-all: ERROR: %S"
-    (dolist (activity (cl-remove-if-not #'activities-activity-active-p (map-values activities-activities)))
-      (let ((activities-saving-p t)
-            ;; Don't write to disk for each activity.
-            (activities-always-persist nil))
-        (activities-save activity :lastp t)))
-    (activities--persist persistp)))
+  (unless (run-hook-with-args-until-success 'activities-anti-save-predicates)
+    (with-demoted-errors "activities-save-all: ERROR: %S"
+      (dolist (activity (cl-remove-if-not #'activities-activity-active-p (map-values activities-activities)))
+        (let ((activities-saving-p t)
+              ;; Don't write to disk for each activity.
+              (activities-always-persist nil))
+          (activities-save activity :lastp t)))
+      (activities--persist persistp))))
 
 (defun activities-revert (activity)
   "Reset ACTIVITY to its default state."
@@ -497,7 +498,8 @@ accordingly."
 (defun activities-mode--killing-emacs ()
   "Persist all activities' states.
 To be called from `kill-emacs-hook'."
-  (let ((activities-always-persist t))
+  (let ((activities-always-persist t)
+        (activities-anti-save-predicates nil))
     (activities-save-all)))
 
 ;;;; Functions
@@ -507,16 +509,16 @@ To be called from `kill-emacs-hook'."
 If DEFAULTP, save its default state; if LASTP, its last.  If
 PERSISTP, force persisting of data (otherwise, data is persisted
 according to option `activities-always-persist', which see)."
-  (activities-with activity
-    (when (or defaultp lastp)
-      (unless (run-hook-with-args-until-success 'activities-anti-save-predicates)
+  (unless (run-hook-with-args-until-success 'activities-anti-save-predicates)
+    (activities-with activity
+      (when (or defaultp lastp)
         (pcase-let* (((cl-struct activities-activity default last) activity)
                      (new-state (activities-state)))
           (setf (activities-activity-default activity) (if (or defaultp (not default)) new-state default)
-                (activities-activity-last activity) (if (or lastp (not last)) new-state last)))))
-    ;; Always set the value so, e.g. the activity can be modified
-    ;; externally and saved here.
-    (setf (map-elt activities-activities (activities-activity-name activity)) activity))
+                (activities-activity-last activity) (if (or lastp (not last)) new-state last))))
+      ;; Always set the value so, e.g. the activity can be modified
+      ;; externally and saved here.
+      (setf (map-elt activities-activities (activities-activity-name activity)) activity)))
   (activities--persist persistp))
 
 (cl-defun activities-set (activity &key (state 'last))


### PR DESCRIPTION
* Moved check of `activities-anti-save-predicates` in `activities-save` to be first
* Added `activities-anti-save-predicates` to `activities-save-all` for future-proof, e.g. in case `activities-with` is used in `activities-save-all` in future for some reason.
* Unset `activities-anti-save-predicates` during `activities-mode--killing-emacs` in order to ensure saving when killed.