### PR TITLE
Fix: (activities-bookmark-handler) Add autoload cookie

### DIFF
--- a/README.org
+++ b/README.org
@@ -157,6 +157,7 @@ When option ~activities-bookmark-store~ is enabled, an Emacs bookmark is stored 
 + Race condition when restoring multiple activities in rapid succession from user code.  ([[https://github.com/alphapapa/activity.el/pull/98][#98]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 + Command ~activities-resume~ resets when called with a universal prefix argument.  ([[https://github.com/alphapapa/activities.el/pull/75][#75]].  Thanks to [[https://breatheoutbreathe.in][Joseph Turner]].)
 + Refreshing activities list.  ([[https://github.com/alphapapa/activities.el/pull/77][#77]].  Thanks to [[https://breatheoutbreathe.in][Joseph Turner]].)
++ Autoload bookmark handler.  ([[https://github.com/alphapapa/activity.el/pull/114][#114]].  Thanks to [[https://breatheoutbreathe.in][Joseph Turner]].)
 
 ** v0.7
 

--- a/activities.el
+++ b/activities.el
@@ -888,6 +888,7 @@ with prefix argument, choose another activity."
                   (handler . activities-bookmark-handler))))
     (bookmark-store bookmark-name props nil)))
 
+;;;###autoload
 (defun activities-bookmark-handler (bookmark)
   "Switch to BOOKMARK's activity."
   (activities-resume (map-elt activities-activities (bookmark-prop-get bookmark 'activities-name))))


### PR DESCRIPTION
Previously, if the user ran bookmark-jump and selected an activity bookmark before activities.el was loaded, Emacs would signal an error.