### PR TITLE
annotate: skip file-truename for remote files

### DIFF
--- a/README.org
+++ b/README.org
@@ -170,6 +170,9 @@ The sort order when completing activities can be configured using ~activities-so
 *Changes*
 + During save, the ~time~ slot for an activity remains unchanged unless its buffers or files differ from their last saved state.  ([[https://github.com/alphapapa/activity.el/pull/83][#83]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
 
+*Fixes*
++ Don't try to compute true filenames for remote files.  (See [[https://github.com/alphapapa/activities.el/issues/130][#130]], [[https://github.com/alphapapa/activities.el/pull/133][#133]].  Thanks to [[https://github.com/jdtsmith][JD Smith]].)
+
 ** v0.7.2
 
 *Fixes*

--- a/activities.el
+++ b/activities.el
@@ -558,12 +558,15 @@ Each of BFA and BFB is a list of buffer and files, as returned
 from `activities--buffers-and-files'."
   (cl-labels ((file-or-buffer (cell)
 		"Given a CELL, return the true filename or buffer.
-The CELL is a (BUFFER . FILE) cons.  If the file is nil, BUFFER is returned."
-		(if-let  ((file (cdr cell)))
-		    (if (file-remote-p file)
-			file
-		      (file-truename file))
-		  (car cell))))
+If the file is a remote one, return its value as-is, not
+necessarily its true name.  The CELL is a (BUFFER . FILE) cons.
+If the file is nil, BUFFER is returned."
+                (pcase-let ((`(,buffer . ,file) cell))
+                  (if file
+                      (if (file-remote-p file)
+                          file
+                        (file-truename file))
+                    buffer))))
     (not (seq-set-equal-p (mapcar #'file-or-buffer bfa)
 			  (mapcar #'file-or-buffer bfb)))))
 

--- a/activities.el
+++ b/activities.el
@@ -559,7 +559,11 @@ from `activities--buffers-and-files'."
   (cl-labels ((file-or-buffer (cell)
 		"Given a CELL, return the true filename or buffer.
 The CELL is a (BUFFER . FILE) cons.  If the file is nil, BUFFER is returned."
-		(if (cdr cell) (file-truename (cdr cell)) (car cell))))
+		(if-let  ((file (cdr cell)))
+		    (if (file-remote-p file)
+			file
+		      (file-truename file))
+		  (car cell))))
     (not (seq-set-equal-p (mapcar #'file-or-buffer bfa)
 			  (mapcar #'file-or-buffer bfb)))))
 


### PR DESCRIPTION
The test for a "dirty" activity used by the annotation function and
when updating the timestamp within the activity is based on whether
the "set of buffers and files" has changed.  We use `file-truename` to
look for "real" file changes but that can hang on remote files.  To
alleviate, we only check the `file-truename` on non-remote files.