### PR TITLE
Make revert and resume callable as action buttons

### DIFF
--- a/activities.el
+++ b/activities.el
@@ -411,6 +411,10 @@ available."
   (interactive
    (list (activities-completing-read :prompt "Resume activity" :default nil)
          :resetp current-prefix-arg))
+  (when (stringp activity)
+    (unless (activities-named activity)
+      (user-error "No activity: %s" activity))
+    (setq activity (activities-named activity)))
   (let ((already-active-p (activities-activity-active-p activity)))
     (activities--switch activity)
     (when (or resetp (not already-active-p))
@@ -464,10 +468,10 @@ this demotes errors."
         (activities-save activity :lastp t)))
     (activities--persist persistp)))
 
-(defun activities-revert (activity)
+(defun activities-revert (&optional activity)
   "Reset ACTIVITY to its default state."
-  (interactive (list (activities-current)))
-  (unless activity
+  (interactive)
+  (unless (or activity (setq activity (activities-current)))
     (user-error "No active activity"))
   ;; TODO: Consider resetting the activity's buffers list.
   (activities-set activity :state 'default))

--- a/activities.el
+++ b/activities.el
@@ -403,22 +403,23 @@ activity."
   (activities--persist))
 
 ;;;###autoload
-(cl-defun activities-resume (activity &key resetp)
-  "Resume ACTIVITY.
+(cl-defun activities-resume (activity-or-name &key resetp)
+  "Resume ACTIVITY-OR-NAME.
 If RESETP (interactively, with universal prefix), reset to
-ACTIVITY's default state; otherwise, resume its last state, if
+ACTIVITY-OR-NAME's default state; otherwise, resume its last state, if
 available."
   (interactive
    (list (activities-completing-read :prompt "Resume activity" :default nil)
          :resetp current-prefix-arg))
-  (when (stringp activity)
-    (unless (activities-named activity)
-      (user-error "No activity: %s" activity))
-    (setq activity (activities-named activity)))
-  (let ((already-active-p (activities-activity-active-p activity)))
-    (activities--switch activity)
-    (when (or resetp (not already-active-p))
-      (activities-set activity :state (if resetp 'default 'last)))))
+  (let ((activity (if (stringp activity-or-name)
+                      (activities-named activity-or-name)
+                    activity-or-name)))
+    (unless activity
+      (user-error "No activity: %s" activity-or-name))
+    (let ((already-active-p (activities-activity-active-p activity)))
+      (activities--switch activity)
+      (when (or resetp (not already-active-p))
+        (activities-set activity :state (if resetp 'default 'last))))))
 
 (defun activities-switch (activity)
   "Switch to ACTIVITY.


### PR DESCRIPTION
# What

Let activities-resume take a string argument so it can be called
directly using an activity's name.

Similarly let activities-revert activity parameter be optional and
default to current activity.

# Why

Proposing a change within the current API instead of adding new
functions. See PR #149 .
