### PR TITLE
Give one more space for the annotation for minibuffer right align

### DIFF
--- a/activities.el
+++ b/activities.el
@@ -984,7 +984,8 @@ which see, with DEFAULT."
                                      'face `(:foreground ,age-color :weight bold)))
                     (dirty-annotation (if dirtyp (propertize "*" 'face 'bold) " ")))
                  (concat (propertize " " 'display
-                                     `(space :align-to (- right ,(+ 1 (length annotation)
+                                     `(space :align-to (- right ,(+ (if (display-graphic-p) 1 2)
+                                                                    (length annotation)
                                                                     (length age-annotation)))))
                          annotation age-annotation dirty-annotation)))))
          (activity-table (str pred action)


### PR DESCRIPTION
Currently the annotation is perfectly right aligned, but this gives unpleasant display under console, which will force a line-wrap and push the ending `*' to the next line.  For example:

```
some-activitiy-1       1 bufs, 0 files, 2 days*
some-activitiy-2       2 bufs, 0 files, 3 days*
```
Will become
```
some-activitiy-1       1 bufs, 0 files, 2 days\
*
some-activitiy-2       2 bufs, 0 files, 3 days\
*
```
This commit adds one more space so that it looks better when running Emacs under console.