### PR TITLE
Add transient menu for activities

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,6 +76,19 @@ This is the recommended configuration, in terms of a ~use-package~ form to be pl
      ("C-x C-a l" . activities-list)))
 #+END_SRC
 
+** Transient menu
+
+As an alternative to binding each command individually, ~activities-transient~ provides a [[https://magit.vc/manual/transient/][transient]] menu that groups all commands in a single keymap:
+
+#+BEGIN_SRC elisp
+  (use-package activities-transient
+    :after activities
+    :bind
+    ("C-x C-a" . activities-transient))
+#+END_SRC
+
+Pressing ~C-x C-a~ will then display a menu with all activities commands organized by category.
+
 * Usage
 
 ** Activities

--- a/activities-transient.el
+++ b/activities-transient.el
@@ -1,0 +1,56 @@
+;;; activities-transient.el --- Transient menu for activities  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Free Software Foundation, Inc.
+
+;; Author: Le Wang <lewang.dev.26@gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This library provides a transient menu for activities commands.
+
+;;; Code:
+
+;;;; Requirements
+
+(require 'transient)
+
+;;;###autoload (autoload 'activities-transient "activities-transient" nil t)
+(transient-define-prefix activities-transient ()
+  "Activities menu.
+C-u modifies some commands:
+  define: redefine existing activity's default state
+  resume: reset to default state instead of last"
+  ["Create & Define"
+   ("n" "New (empty)" activities-new)
+   ("d" "Define (C-u: redefine default)" activities-define)]
+  ["Switch & Resume"
+   ("a" "Resume (C-u: reset to default)" activities-resume)
+   ("RET" "Switch (active)" activities-switch)
+   ("b" "Switch buffer" activities-switch-buffer)]
+  ["Modify"
+   ("g" "Revert to default" activities-revert)
+   ("R" "Rename" activities-rename)]
+  ["Close"
+   ("s" "Suspend (save & close)" activities-suspend)
+   ("k" "Kill (discard last & close)" activities-kill)
+   ("X" "Discard (permanent)" activities-discard)]
+  ["Other"
+   ("S" "Save all" activities-save-all)
+   ("l" "List" activities-list)])
+
+(provide 'activities-transient)
+
+;;; activities-transient.el ends here


### PR DESCRIPTION
## Summary

Add `activities-transient.el`, a transient-based menu for common activities operations, and document
it in the README as an alternative to individual keybindings.

Groups commands into logical sections:
- **Create & Define**: new, define (with C-u to redefine default state)
- **Switch & Resume**: resume (with C-u to reset), switch active, switch buffer
- **Modify**: revert, rename
- **Close**: suspend, kill, discard
- **Other**: save all, list

## Usage

```elisp
(use-package activities-transient
  :after activities
  :bind
  ("C-x C-a" . activities-transient))
```

## Notes

- Only requires `transient` — no dependency on activities.el internals
- Uses autoload cookie for lazy loading
- README updated with transient menu configuration section