### PR TITLE
Fix: Prevent bookmark-alist pollution on activity resume

### DIFF
--- a/activities.el
+++ b/activities.el
@@ -832,7 +832,7 @@ activity's name is NAME."
                   (save-window-excursion
                     (condition-case err
                         (progn
-                          (bookmark-jump bookmark)
+                          (funcall (or (bookmark-get-handler bookmark) 'bookmark-default-handler) bookmark)
                           (when-let ((local-variable-map
                                       (bookmark-prop-get bookmark 'activities-buffer-local-variables)))
                             (cl-loop for (variable . value) in local-variable-map


### PR DESCRIPTION
## Summary

- `activities--bookmark-buffer` calls `bookmark-jump` to restore buffers, which as a side effect adds each
  bookmark record to `bookmark-alist`
- Every resume accumulates more entries, littering the bookmark UI
- Call the bookmark handler directly instead of going through `bookmark-jump`, bypassing the `bookmark-alist`
  mutation entirely